### PR TITLE
typo fix in _transport_factory.py docstring

### DIFF
--- a/pycyphal/application/_transport_factory.py
+++ b/pycyphal/application/_transport_factory.py
@@ -26,7 +26,7 @@ def make_transport(
 
     The register schema is documented below per transport class
     (refer to the transport class documentation to find the defaults for optional registers).
-    All transports also accept the following standard regsiters:
+    All transports also accept the following standard registers:
 
     +-------------------+-------------------+-----------------------------------------------------------------------+
     | Register name     | Register type     | Semantics                                                             |


### PR DESCRIPTION
"regsiters" changed to "registers" in docstring.
Instead of messed pull request https://github.com/OpenCyphal/pycyphal/pull/331