### PR TITLE
Fix CI on Linux

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -43,13 +43,12 @@ jobs:
       - name: Build and Install Socketcand
         if: ${{ runner.os == 'Linux' }}
         run: |
-          sudo apt-get install -y autoconf
+          sudo apt-get install -y meson libconfig-dev
           git clone https://github.com/linux-can/socketcand.git
           cd socketcand
-          ./autogen.sh
-          ./configure
-          make
-          sudo make install
+          meson setup -Dlibconfig=true --buildtype=release build
+          meson compile -C build
+          sudo meson install -C build
 
       - name: Collect Linux diagnostic data
         if: ${{ runner.os == 'Linux' }}
@@ -73,10 +72,11 @@ jobs:
         shell: bash
 
       - name: Save logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: PyCyphal-${{ matrix.os }}-python-${{ matrix.python }}
-          path: .nox/*/*/*.log
+          path: .nox/**/*.log
+          include-hidden-files: true
           retention-days: 7
 
   pycyphal-release:

--- a/noxfile.py
+++ b/noxfile.py
@@ -75,7 +75,10 @@ def test(session):
         session.run("sudo", "setcap", "cap_net_raw+eip", str(Path(session.bin, "python").resolve()), external=True)
 
     # Launch the TCP broker for testing the Cyphal/serial transport.
-    broker_process = subprocess.Popen(["ncat", "--broker", "--listen", "-p", "50905"], env=session.env)
+    broker_process = subprocess.Popen(
+        ["ncat", "--broker", "--listen", "-p", "50905"],
+        env={k: v for k, v in session.env.items() if v is not None},
+    )
     time.sleep(1.0)  # Ensure that it has started.
     if broker_process.poll() is not None:
         raise RuntimeError("Could not start the TCP broker")


### PR DESCRIPTION
The Ubuntu CI job had two issues:

1. [`actions/upload-artifact@v3`](https://github.com/actions/upload-artifact) was deprecated some time ago and not available anymore
2. The [socketcand](https://github.com/linux-can/socketcand) project had been migrated to a meson-based build process

This PR fixes both issues, resulting in a working Linux CI test again.


I was not able to test the Windows setup, as I don't have access to _windows-2019-npcap_ machines.